### PR TITLE
Use a wrapper task so that we show overall progress through the export

### DIFF
--- a/animation_workbench.py
+++ b/animation_workbench.py
@@ -147,8 +147,10 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         self.help_button.toggled.connect(self.help_toggled)
 
         # Close button action (save state on close)
-        self.button_box.rejected.connect(self.close)
+        self.button_box.button(QDialogButtonBox.Close).clicked.connect(self.close)
         self.button_box.accepted.connect(self.accept)
+
+        self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
 
         # Used by ffmpeg and convert to set the fps for rendered videos
         self.framerate_spin.setValue(
@@ -588,10 +590,12 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
             self.output_log_text_edit.append(job.file_name)
             self.render_queue.add_job(job)
 
+        self.button_box.button(QDialogButtonBox.Cancel).setEnabled(True)
         # Now all the tasks are prepared, start the render_queue processing
         self.render_queue.start_processing()
 
     def cancel_processing(self):
+        self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
         self.render_queue.cancel_processing()
 
     def create_controller(self) -> Optional[AnimationController]:
@@ -655,11 +659,18 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
 
         return controller
 
-    def processing_completed(self):
+    def processing_completed(self, success: bool):
         """Run after all processing is done to generate gif or mp4.
 
         .. note:: This called by process_more_tasks when all tasks are complete.
         """
+        if not success:
+            self.output_log_text_edit.append('Canceled by user')
+            self.progress_bar.setMaximum(100)
+            self.progress_bar.setValue(0)
+            self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
+            return
+
         self.movie_task = MovieCreationTask(
             output_file=self.movie_file_edit.text(),
             music_file=self.music_file_edit.text(),
@@ -697,6 +708,8 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         self.movie_task.taskTerminated.connect(cleanup_movie_task)
 
         QgsApplication.taskManager().addTask(self.movie_task)
+
+        self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
 
     def show_preview_for_frame(self, frame: int):
         if self.radio_sphere.isChecked() or self.radio_planar.isChecked():

--- a/render_queue.py
+++ b/render_queue.py
@@ -27,7 +27,13 @@ import qgis  # pylint: disable=unused-import
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtGui import QImage
 from qgis.core import QgsApplication, QgsMapRendererParallelJob
-from qgis.core import QgsMapRendererTask, QgsMapSettings
+from qgis.core import (
+    QgsMapRendererTask,
+    QgsMapSettings,
+    QgsProxyProgressTask,
+    QgsFeedback,
+    Qgis
+)
 
 from .settings import setting
 
@@ -63,10 +69,25 @@ class RenderJob:
         return task
 
 
+class RenderQueueFeedback(QgsFeedback):
+
+    def __init__(self, steps: int):
+        super().__init__()
+        self.steps = steps
+        self.current_step = 0
+
+    def set_current_step(self, step: int):
+        self.current_step = step
+        self.setProgress(100*self.current_step/self.steps)
+
+    def set_remaining_steps(self, remaining: int):
+        self.set_current_step(self.steps - remaining)
+
+
 class RenderQueue(QObject):
     # Signals
     status_changed = pyqtSignal()
-    processing_completed = pyqtSignal()
+    processing_completed = pyqtSignal(bool)
     status_message = pyqtSignal(str)
     # Sends the path to each frame as it is rendered
     image_rendered = pyqtSignal(str)
@@ -88,6 +109,10 @@ class RenderQueue(QObject):
         self.job_queue: List[RenderJob] = []
         self.active_tasks = {}
 
+        # "parent" task which just reports overall progress of the queue
+        self.proxy_task: Optional[QgsProxyProgressTask] = None
+        self.proxy_feedback: Optional[RenderQueueFeedback] = None
+
         self.verbose_mode = int(setting(key="verbose_mode", default=0))
         self.total_queue_size = 0
         self.total_completed = 0
@@ -104,6 +129,8 @@ class RenderQueue(QObject):
     def reset(self):
         self.job_queue.clear()
         self.active_tasks.clear()
+        self.proxy_task = None
+        self.proxy_feedback = None
 
         self.total_queue_size = 0
         self.total_completed = 0
@@ -123,10 +150,19 @@ class RenderQueue(QObject):
         self.total_feature_count = 0
         self.completed_feature_count = 0
 
+        self.proxy_feedback.cancel()
+
+        for _, task in self.active_tasks.items():
+            task.cancel()
+
+        if self.proxy_task:
+            self.proxy_task.finalize(False)
+            self.proxy_task = None
+
         self.frames_per_feature = 0
         self.annotations_list = []
         self.decorations = []
-        self.status_message.emit(f"Cancelling after in progress jobs are done")
+        self.status_message.emit(f"Cancelling...")
 
     def update_status(self):
         # make sure internal counters are consistent
@@ -135,6 +171,18 @@ class RenderQueue(QObject):
         self.status_changed.emit()
 
     def start_processing(self):
+        if Qgis.QGIS_VERSION_INT >= 32500:
+            self.proxy_task = QgsProxyProgressTask('Exporting frames', True)
+            self.proxy_task.canceled.connect(self.cancel_processing)
+        else:
+            # can't set a proxy task as cancelable in < 3.26 :(
+            self.proxy_task = QgsProxyProgressTask('Exporting frames')
+
+        self.proxy_feedback = RenderQueueFeedback(len(self.job_queue))
+        self.proxy_feedback.progressChanged.connect(self.proxy_task.setProxyProgress)
+
+        QgsApplication.taskManager().addTask(self.proxy_task)
+
         self.process_queue()
 
     def process_queue(self):
@@ -143,10 +191,16 @@ class RenderQueue(QObject):
         """
         if not self.job_queue and not self.active_tasks:
             # all done!
-            self.processing_completed.emit()
+            self.update_status()
+            was_canceled = self.proxy_feedback and self.proxy_feedback.isCanceled()
+            self.processing_completed.emit(not was_canceled)
+            if self.proxy_task:
+                self.proxy_task.finalize(not was_canceled)
+                self.proxy_task = None
+            return
 
         if not self.job_queue:
-            # no more jobs to add
+            # no more jobs to add, but still running some jobs
             self.update_status()
             return
 
@@ -167,6 +221,7 @@ class RenderQueue(QObject):
             )
 
             QgsApplication.taskManager().addTask(task)
+            self.proxy_feedback.set_remaining_steps(len(self.job_queue))
 
         self.update_status()
 


### PR DESCRIPTION
in the task manager, and make cancelation more responsive by immediately
canceling in progress render jobs