### PR TITLE
Add a loop option for travelling animations

### DIFF
--- a/animation_workbench/animation_workbench.py
+++ b/animation_workbench/animation_workbench.py
@@ -226,6 +226,15 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
                 )
             )
         )
+
+        self.check_loop_features.setChecked(
+            setting(
+                key="loop",
+                default="false",
+                prefer_project_setting=True,
+            ).lower()
+            == "true"
+        )
         # How many frames to render when we are in static mode
         self.extent_frames_spin.setValue(
             int(
@@ -545,6 +554,11 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
             store_in_project=True,
         )
         set_setting(
+            key="loop",
+            value="true" if self.check_loop_features.isChecked() else "false",
+            store_in_project=True,
+        )
+        set_setting(
             key="frames_for_extent",
             value=self.extent_frames_spin.value(),
             store_in_project=True,
@@ -726,6 +740,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
                     hover_duration=self.hover_duration_spin.value(),
                     min_scale=self.scale_range.minimumScale(),
                     max_scale=self.scale_range.maximumScale(),
+                    loop=self.check_loop_features.isChecked(),
                     pan_easing=self.pan_easing_widget.get_easing()
                     if self.pan_easing_widget.is_enabled()
                     else None,

--- a/animation_workbench/test/test_animation_controller.py
+++ b/animation_workbench/test/test_animation_controller.py
@@ -8,6 +8,8 @@
 
 """
 
+# pylint: disable=too-many-lines
+
 __author__ = "(C) 2018 by Nyall Dawson"
 __date__ = "20/04/2018"
 __copyright__ = "Copyright 2018, North Road"

--- a/animation_workbench/test/test_animation_controller.py
+++ b/animation_workbench/test/test_animation_controller.py
@@ -830,6 +830,319 @@ class AnimationControllerTest(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(it)
 
+    def test_planar_loop(self):
+        """
+        Test a planar job with looping
+        """
+
+        vl = QgsVectorLayer("Point?crs=EPSG:4326&field=name:string", "vl", "memory")
+        self.assertTrue(vl.isValid())
+
+        f = QgsFeature(vl.fields())
+        f["name"] = "f1"
+        f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(1, 2)))
+        self.assertTrue(vl.dataProvider().addFeature(f))
+
+        f["name"] = "f2"
+        f.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(10, 20)))
+        self.assertTrue(vl.dataProvider().addFeature(f))
+
+        map_settings = QgsMapSettings()
+        map_settings.setExtent(QgsRectangle(1, 2, 3, 4))
+        map_settings.setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:4326"))
+        map_settings.setOutputSize(QSize(400, 300))
+        controller = AnimationController.create_moving_extent_controller(
+            map_settings=map_settings,
+            mode=MapMode.PLANAR,
+            feature_layer=vl,
+            travel_duration=2,
+            hover_duration=1,
+            min_scale=2000000,
+            max_scale=1000000,
+            pan_easing=QEasingCurve(QEasingCurve.Type.Linear),
+            zoom_easing=QEasingCurve(QEasingCurve.Type.Linear),
+            frame_rate=2,
+            loop=True,
+        )
+
+        it = controller.create_jobs()
+
+        job = next(it)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 0)
+        self.assertAlmostEqual(job.map_settings.scale(), 1000000, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 1, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 2, 2)
+        self.assertAlmostEqual(
+            job.map_settings.expressionContext().variable("map_scale"),
+            1000000,
+            delta=120000,
+        )
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 1, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 2, 2)
+        self.assertAlmostEqual(job.map_settings.scale(), 1000000, delta=120000)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 1)
+
+        # now we start panning
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1000000, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 1, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 2, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 2)
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1666666, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 4, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 8, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 3)
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1666666, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 7, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 14, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 4)
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1000000, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 10, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 20, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 5)
+
+        # back to hovering
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1000000, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 10, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 20, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 6)
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1000000, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 10, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 20, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 7)
+
+        # travel from last to first
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1000000, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 10, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 20, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 8)
+        self.assertAlmostEqual(
+            job.map_settings.expressionContext().variable("map_scale"),
+            1000000,
+            delta=120000,
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("frame_number"), 8
+        )
+        self.assertEqual(job.map_settings.expressionContext().variable("frame_rate"), 2)
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("hover_feature")
+        )
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("hover_feature_id")
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("from_feature").id(), 2
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("from_feature_id"), 2
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("to_feature").id(), 1
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("to_feature_id"), 1
+        )
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("current_hover_frame")
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("current_travel_frame"), 0
+        )
+        self.assertIsNone(job.map_settings.expressionContext().variable("hover_frames"))
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("travel_frames"), 4
+        )
+        self.assertEqual(job.map_settings.expressionContext().feature().id(), 2)
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("total_frame_count"), 12
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("current_animation_action"),
+            "Travelling",
+        )
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1666666, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 7, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 14, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 9)
+        self.assertAlmostEqual(
+            job.map_settings.expressionContext().variable("map_scale"),
+            1666666,
+            delta=120000,
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("frame_number"), 9
+        )
+        self.assertEqual(job.map_settings.expressionContext().variable("frame_rate"), 2)
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("hover_feature")
+        )
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("hover_feature_id")
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("from_feature").id(), 2
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("from_feature_id"), 2
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("to_feature").id(), 1
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("to_feature_id"), 1
+        )
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("current_hover_frame")
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("current_travel_frame"), 1
+        )
+        self.assertIsNone(job.map_settings.expressionContext().variable("hover_frames"))
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("travel_frames"), 4
+        )
+        self.assertEqual(job.map_settings.expressionContext().feature().id(), 2)
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("total_frame_count"), 12
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("current_animation_action"),
+            "Travelling",
+        )
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1666666, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 4, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 8, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 10)
+        self.assertAlmostEqual(
+            job.map_settings.expressionContext().variable("map_scale"),
+            1666666,
+            delta=120000,
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("frame_number"), 10
+        )
+        self.assertEqual(job.map_settings.expressionContext().variable("frame_rate"), 2)
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("hover_feature")
+        )
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("hover_feature_id")
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("from_feature").id(), 2
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("from_feature_id"), 2
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("to_feature").id(), 1
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("to_feature_id"), 1
+        )
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("current_hover_frame")
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("current_travel_frame"), 2
+        )
+        self.assertIsNone(job.map_settings.expressionContext().variable("hover_frames"))
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("travel_frames"), 4
+        )
+        self.assertEqual(job.map_settings.expressionContext().feature().id(), 2)
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("total_frame_count"), 12
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("current_animation_action"),
+            "Travelling",
+        )
+
+        job = next(it)
+        self.assertAlmostEqual(job.map_settings.scale(), 1000000, delta=120000)
+        self.assertAlmostEqual(job.map_settings.extent().center().x(), 1, 2)
+        self.assertAlmostEqual(job.map_settings.extent().center().y(), 2, 2)
+        self.assertEqual(job.map_settings.frameRate(), 2)
+        self.assertEqual(job.map_settings.currentFrame(), 11)
+        self.assertAlmostEqual(
+            job.map_settings.expressionContext().variable("map_scale"),
+            1000000,
+            delta=120000,
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("frame_number"), 11
+        )
+        self.assertEqual(job.map_settings.expressionContext().variable("frame_rate"), 2)
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("hover_feature")
+        )
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("hover_feature_id")
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("from_feature").id(), 2
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("from_feature_id"), 2
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("to_feature").id(), 1
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("to_feature_id"), 1
+        )
+        self.assertIsNone(
+            job.map_settings.expressionContext().variable("current_hover_frame")
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("current_travel_frame"), 3
+        )
+        self.assertIsNone(job.map_settings.expressionContext().variable("hover_frames"))
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("travel_frames"), 4
+        )
+        self.assertEqual(job.map_settings.expressionContext().feature().id(), 2)
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("total_frame_count"), 12
+        )
+        self.assertEqual(
+            job.map_settings.expressionContext().variable("current_animation_action"),
+            "Travelling",
+        )
+
+        with self.assertRaises(StopIteration):
+            next(it)
+
 
 if __name__ == "__main__":
     suite = unittest.makeSuite(AnimationControllerTest)

--- a/animation_workbench/ui/animation_workbench_base.ui
+++ b/animation_workbench/ui/animation_workbench_base.ui
@@ -514,8 +514,18 @@ zoom to each point.</string>
             <layout class="QGridLayout" name="gridLayout_2">
              <item row="0" column="0" colspan="2">
               <widget class="QgsMapLayerComboBox" name="layer_combo">
-               <property name="allowEmptyLayer">
+               <property name="allowEmptyLayer" stdset="0">
                 <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QCheckBox" name="check_loop_features">
+               <property name="toolTip">
+                <string>If checked, an extra travel stage from the final feature back to the first feature will be added, resulting in a seamless looping animation</string>
+               </property>
+               <property name="text">
+                <string>Loop from final feature back to first feature</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
Adds an extra travel stage from last feature back to first, so
that you can create seamless looping animations

Fixes #12