### PR TITLE
Tab UI

### DIFF
--- a/animation_workbench/animation_workbench.py
+++ b/animation_workbench/animation_workbench.py
@@ -108,7 +108,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         QDialog.__init__(self, parent)
         self.setupUi(self)
         self.expression_context_generator = DialogExpressionContextGenerator()
-        self.main_stack.setCurrentIndex(0)
+        self.main_tab.setCurrentIndex(1)
         self.extent_group_box = QgsExtentWidget(None, QgsExtentWidget.ExpandedStyle)
         vbox_layout = QVBoxLayout()
         vbox_layout.addWidget(self.extent_group_box)
@@ -370,7 +370,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         layout = QGridLayout(self.video_preview_widget)
         layout.addWidget(video_widget)
         # Enable options page on startup
-        self.main_stack.setCurrentIndex(0)
+        self.main_tab.setCurrentIndex(1)
         # Enable easing status page on startup
         self.render_queue.status_changed.connect(self.show_status)
         self.render_queue.processing_completed.connect(self.processing_completed)
@@ -628,8 +628,8 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
 
         .. note:: This is called on OK click.
         """
-        # Enable progress page on startup
-        self.main_stack.setCurrentIndex(1)
+        # Enable progress page on accept
+        self.main_tab.setCurrentIndex(4)
         # Image preview page
         self.preview_stack.setCurrentIndex(0)
         # Enable queue status page
@@ -639,7 +639,6 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
             os.system("rm %s/%s*" % (self.work_directory, self.frame_filename_prefix))
 
         self.save_state()
-        self.run_frame.show()
 
         self.render_queue.reset()
         self.last_preview_image = None
@@ -691,7 +690,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
         self.render_queue.cancel_processing()
         # Enable progress page
-        self.main_stack.setCurrentIndex(0)
+        self.main_tab.setCurrentIndex(1)
 
     def create_controller(self) -> Optional[AnimationController]:
         """
@@ -786,7 +785,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
 
         def show_movie(movie_file: str):
             # Video preview page
-            self.main_stack.setCurrentIndex(1)
+            self.main_tab.setCurrentIndex(4)
             self.preview_stack.setCurrentIndex(1)
             self.media_player.setMedia(QMediaContent(QUrl.fromLocalFile(movie_file)))
             self.play_button.setEnabled(True)
@@ -808,7 +807,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         QgsApplication.taskManager().addTask(self.movie_task)
 
         self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
-        self.main_stack.setCurrentIndex(0)
+        self.main_tab.setCurrentIndex(1)
 
     def show_preview_for_frame(self, frame: int):
         """

--- a/animation_workbench/animation_workbench.py
+++ b/animation_workbench/animation_workbench.py
@@ -108,7 +108,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         QDialog.__init__(self, parent)
         self.setupUi(self)
         self.expression_context_generator = DialogExpressionContextGenerator()
-        self.main_tab.setCurrentIndex(1)
+        self.main_tab.setCurrentIndex(0)
         self.extent_group_box = QgsExtentWidget(None, QgsExtentWidget.ExpandedStyle)
         vbox_layout = QVBoxLayout()
         vbox_layout.addWidget(self.extent_group_box)
@@ -370,7 +370,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         layout = QGridLayout(self.video_preview_widget)
         layout.addWidget(video_widget)
         # Enable options page on startup
-        self.main_tab.setCurrentIndex(1)
+        self.main_tab.setCurrentIndex(0)
         # Enable easing status page on startup
         self.render_queue.status_changed.connect(self.show_status)
         self.render_queue.processing_completed.connect(self.processing_completed)
@@ -690,7 +690,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
         self.render_queue.cancel_processing()
         # Enable progress page
-        self.main_tab.setCurrentIndex(1)
+        self.main_tab.setCurrentIndex(0)
 
     def create_controller(self) -> Optional[AnimationController]:
         """
@@ -807,7 +807,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         QgsApplication.taskManager().addTask(self.movie_task)
 
         self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
-        self.main_tab.setCurrentIndex(1)
+        self.main_tab.setCurrentIndex(0)
 
     def show_preview_for_frame(self, frame: int):
         """

--- a/animation_workbench/core/animation_controller.py
+++ b/animation_workbench/core/animation_controller.py
@@ -33,6 +33,7 @@ from qgis.core import (
 )
 
 from .render_queue import RenderJob
+from .utilities import calculate_cardinality
 
 
 class MapMode(Enum):
@@ -382,6 +383,7 @@ class AnimationController(QObject):
             )
             scope.setVariable("to_feature", feature, True)
             scope.setVariable("to_feature_id", feature.id(), True)
+
             scope.setVariable("hover_feature", feature, True)
             scope.setVariable("hover_feature_id", feature.id(), True)
             context.appendScope(scope)

--- a/animation_workbench/core/animation_controller.py
+++ b/animation_workbench/core/animation_controller.py
@@ -33,7 +33,6 @@ from qgis.core import (
 )
 
 from .render_queue import RenderJob
-from .utilities import calculate_cardinality
 
 
 class MapMode(Enum):

--- a/animation_workbench/core/animation_workbench.py
+++ b/animation_workbench/core/animation_workbench.py
@@ -1,0 +1,921 @@
+# coding=utf-8
+"""This module has the main GUI interaction logic for AnimationWorkbench."""
+
+__copyright__ = "Copyright 2022, Tim Sutton"
+__license__ = "GPL version 3"
+__email__ = "tim@kartoza.com"
+__revision__ = "$Format:%H$"
+
+# This will make the QGIS use a world projection and then move the center
+# of the CRS sequentially to create a spinning globe effect
+import os
+import tempfile
+from functools import partial
+from typing import Optional
+
+from PyQt5.QtMultimedia import QMediaContent, QMediaPlayer
+from PyQt5.QtMultimediaWidgets import QVideoWidget
+from qgis.PyQt.QtCore import pyqtSlot, QUrl
+from qgis.PyQt.QtGui import QIcon, QPixmap, QImage
+from qgis.PyQt.QtWidgets import (
+    QStyle,
+    QFileDialog,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QVBoxLayout,
+)
+from qgis.PyQt.QtXml import QDomDocument
+from qgis.core import (
+    QgsExpressionContextUtils,
+    QgsProject,
+    QgsMapLayerProxyModel,
+    QgsReferencedRectangle,
+    QgsApplication,
+    QgsExpressionContextGenerator,
+    QgsPropertyCollection,
+    QgsExpressionContext,
+    QgsVectorLayer,
+    QgsWkbTypes,
+)
+from qgis.gui import QgsExtentWidget, QgsPropertyOverrideButton
+
+from .core import (
+    AnimationController,
+    InvalidAnimationParametersException,
+    MovieCreationTask,
+    MovieFormat,
+    set_setting,
+    setting,
+    MapMode,
+)
+from .utilities import get_ui_class, resources_path
+
+FORM_CLASS = get_ui_class("animation_workbench_base.ui")
+
+
+class DialogExpressionContextGenerator(QgsExpressionContextGenerator):
+    """
+    An expression context generator for widgets in the dialog
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.layer = None
+
+    def set_layer(self, layer: QgsVectorLayer):
+        """
+        Sets the layer associated with the dialog
+        """
+        self.layer = layer
+
+    # pylint: disable=missing-function-docstring
+    def createExpressionContext(
+        self,
+    ) -> QgsExpressionContext:
+        context = QgsExpressionContext()
+        context.appendScope(QgsExpressionContextUtils.globalScope())
+        context.appendScope(
+            QgsExpressionContextUtils.projectScope(QgsProject.instance())
+        )
+        if self.layer:
+            context.appendScope(self.layer.createExpressionContextScope())
+        return context
+
+
+# pylint: disable=too-many-public-methods
+class AnimationWorkbench(QDialog, FORM_CLASS):
+    """Dialog implementation class Animation Workbench class."""
+
+    # pylint: disable=too-many-locals,too-many-statements
+    def __init__(
+        self,
+        parent=None,
+        iface=None,
+        render_queue=None,
+    ):
+        """Constructor for the workbench dialog.
+
+        :param parent: Parent widget of this dialog.
+        :type parent: QWidget
+
+        :param iface: QGIS Plugin Interface.
+        :type iface: QgsInterface
+
+        :param render_queue: Render queue to processing each frame.
+        :type render_queue: RenderQueue
+        """
+        QDialog.__init__(self, parent)
+        self.setupUi(self)
+        self.expression_context_generator = DialogExpressionContextGenerator()
+        self.main_tab.setCurrentIndex(1)
+        self.extent_group_box = QgsExtentWidget(None, QgsExtentWidget.ExpandedStyle)
+        vbox_layout = QVBoxLayout()
+        vbox_layout.addWidget(self.extent_group_box)
+        self.extent_widget_container.setLayout(vbox_layout)
+
+        self.render_queue = render_queue
+        self.setWindowTitle(self.tr("Animation Workbench"))
+        icon = resources_path("icons", "animation-workbench.svg")
+        self.setWindowIcon(QIcon(icon))
+        self.parent = parent
+        self.iface = iface
+
+        self.data_defined_properties = QgsPropertyCollection()
+
+        self.extent_group_box.setMapCanvas(self.iface.mapCanvas())
+        self.scale_range.setMapCanvas(self.iface.mapCanvas())
+
+        self.output_log_text_edit.append("Welcome to the QGIS Animation Workbench")
+        self.output_log_text_edit.append("© Tim Sutton, Feb 2022")
+
+        ok_button = self.button_box.button(QDialogButtonBox.Ok)
+        # ok_button.clicked.connect(self.accept)
+        ok_button.setText("Run")
+        ok_button.setEnabled(False)
+
+        self.cancel_button = self.button_box.button(QDialogButtonBox.Cancel)
+        self.cancel_button.clicked.connect(self.cancel_processing)
+
+        # place where working files are stored
+        self.work_directory = tempfile.gettempdir()
+        self.frame_filename_prefix = "animation_workbench"
+        # place where final products are stored
+        output_file = setting(
+            key="output_file", default="", prefer_project_setting=True
+        )
+        if output_file:
+            self.movie_file_edit.setText(output_file)
+            ok_button.setEnabled(True)
+
+        self.movie_file_button.clicked.connect(self.set_output_name)
+
+        music_file = setting(key="music_file", default="", prefer_project_setting=True)
+        if music_file:
+            self.music_file_edit.setText(music_file)
+        self.music_file_button.clicked.connect(self.choose_music_file)
+
+        # Work around for not being able to set the layer
+        # types allowed in the QgsMapLayerSelector combo
+        # See https://github.com/qgis/QGIS/issues/38472#issuecomment-715178025
+        self.layer_combo.setFilters(
+            QgsMapLayerProxyModel.PointLayer
+            | QgsMapLayerProxyModel.LineLayer
+            | QgsMapLayerProxyModel.PolygonLayer
+        )
+        self.layer_combo.layerChanged.connect(self._layer_changed)
+
+        prev_layer_id, _ = QgsProject.instance().readEntry("animation", "layer_id")
+        if prev_layer_id:
+            layer = QgsProject.instance().mapLayer(prev_layer_id)
+            if layer:
+                self.layer_combo.setLayer(layer)
+
+        prev_data_defined_properties_xml, _ = QgsProject.instance().readEntry(
+            "animation", "data_defined_properties"
+        )
+        if prev_data_defined_properties_xml:
+            doc = QDomDocument()
+            doc.setContent(prev_data_defined_properties_xml.encode())
+            elem = doc.firstChildElement("data_defined_properties")
+            self.data_defined_properties.readXml(
+                elem, AnimationController.DYNAMIC_PROPERTIES
+            )
+
+        self.extent_group_box.setOutputCrs(QgsProject.instance().crs())
+        self.extent_group_box.setOutputExtentFromUser(
+            self.iface.mapCanvas().extent(), QgsProject.instance().crs()
+        )
+        # self.extent_group_box.setOriginalExtnt()
+
+        # Close button action (save state on close)
+        self.button_box.button(QDialogButtonBox.Close).clicked.connect(self.close)
+        self.button_box.accepted.connect(self.accept)
+
+        self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
+
+        # Used by ffmpeg and convert to set the fps for rendered videos
+        self.framerate_spin.setValue(
+            int(
+                setting(
+                    key="frames_per_second",
+                    default="90",
+                    prefer_project_setting=True,
+                )
+            )
+        )
+
+        # How many seconds to render for each feature pair transition
+        self.hover_duration_spin.setValue(
+            float(
+                setting(
+                    key="hover_duration",
+                    default="2",
+                    prefer_project_setting=True,
+                )
+            )
+        )
+
+        # How many seconds to hover at each feature for
+        self.travel_duration_spin.setValue(
+            float(
+                setting(
+                    key="travel_duration",
+                    default="2",
+                    prefer_project_setting=True,
+                )
+            )
+        )
+
+        self.check_loop_features.setChecked(
+            setting(
+                key="loop",
+                default="false",
+                prefer_project_setting=True,
+            ).lower()
+            == "true"
+        )
+        # How many frames to render when we are in static mode
+        self.extent_frames_spin.setValue(
+            int(
+                setting(
+                    key="frames_for_extent",
+                    default="90",
+                    prefer_project_setting=True,
+                )
+            )
+        )
+        # Keep the scales the same if you dont want it to zoom in an out
+        max_scale = float(
+            setting(
+                key="max_scale",
+                default="10000000",
+                prefer_project_setting=True,
+            )
+        )
+        min_scale = float(
+            setting(
+                key="min_scale",
+                default="25000000",
+                prefer_project_setting=True,
+            )
+        )
+        self.scale_range.setScaleRange(min_scale, max_scale)
+        # We need to set min and max at the same time to prevent
+        # the scale widget from overriding our preferred values
+        self.last_preview_image = None
+
+        # Note: self.pan_easing_widget and zoom_easing_preview are
+        # custom widgets implemented in easing_preview.py
+        # and added in designer as promoted widgets.
+        self.pan_easing_widget.set_checkbox_label("Enable Pan Easing")
+        pan_easing_name = setting(
+            key="pan_easing", default="Linear", prefer_project_setting=True
+        )
+        self.pan_easing_widget.set_preview_color("#ffff00")
+        self.pan_easing_widget.set_easing_by_name(pan_easing_name)
+        if (
+            int(
+                setting(
+                    key="enable_pan_easing",
+                    default=0,
+                    prefer_project_setting=True,
+                )
+            )
+            == 0
+        ):
+            self.pan_easing_widget.disable()
+        else:
+            self.pan_easing_widget.enable()
+
+        self.zoom_easing_widget.set_checkbox_label("Enable Zoom Easing")
+        zoom_easing_name = setting(
+            key="zoom_easing", default="Linear", prefer_project_setting=True
+        )
+        self.zoom_easing_widget.set_preview_color("#0000ff")
+        self.zoom_easing_widget.set_easing_by_name(zoom_easing_name)
+        if (
+            int(
+                setting(
+                    key="enable_zoom_easing",
+                    default=0,
+                    prefer_project_setting=True,
+                )
+            )
+            == 0
+        ):
+            self.zoom_easing_widget.disable()
+        else:
+            self.zoom_easing_widget.enable()
+
+        QgsExpressionContextUtils.setProjectVariable(
+            QgsProject.instance(), "frames_per_feature", 0
+        )
+        QgsExpressionContextUtils.setProjectVariable(
+            QgsProject.instance(), "current_frame_for_feature", 0
+        )
+        QgsExpressionContextUtils.setProjectVariable(
+            QgsProject.instance(), "dwell_frames_per_feature", 0
+        )
+        QgsExpressionContextUtils.setProjectVariable(
+            QgsProject.instance(), "current_feature_id", 0
+        )
+        # None, Panning, Hovering
+        QgsExpressionContextUtils.setProjectVariable(
+            QgsProject.instance(), "current_animation_action", "None"
+        )
+
+        QgsExpressionContextUtils.setProjectVariable(
+            QgsProject.instance(), "total_frame_count", "None"
+        )
+
+        mode_string = setting(
+            key="map_mode", default="sphere", prefer_project_setting=True
+        )
+        if mode_string == "sphere":
+            self.radio_sphere.setChecked(True)
+            self.settings_stack.setCurrentIndex(0)
+        elif mode_string == "planar":
+            self.radio_planar.setChecked(True)
+            self.settings_stack.setCurrentIndex(0)
+        else:
+            self.radio_extent.setChecked(True)
+            self.settings_stack.setCurrentIndex(1)
+
+        self.radio_planar.toggled.connect(self.show_non_fixed_extent_settings)
+        self.radio_sphere.toggled.connect(self.show_non_fixed_extent_settings)
+        self.radio_extent.toggled.connect(self.show_fixed_extent_settings)
+
+        self.current_preview_frame_render_job = None
+        # Set an initial image in the preview based on the current map
+        self.show_preview_for_frame(0)
+
+        self.progress_bar.setValue(0)
+
+        self.reuse_cache.setChecked(False)
+
+        # Video playback stuff - see bottom of file for related methods
+        self.media_player = QMediaPlayer(
+            None, QMediaPlayer.VideoSurface  # .video_preview_widget,
+        )
+        video_widget = QVideoWidget()
+        # self.video_page.replaceWidget(self.video_preview_widget,video_widget)
+        self.play_button.setIcon(self.style().standardIcon(QStyle.SP_MediaPlay))
+        self.play_button.clicked.connect(self.play)
+        self.media_player.setVideoOutput(video_widget)
+        self.media_player.stateChanged.connect(self.media_state_changed)
+        self.media_player.positionChanged.connect(self.position_changed)
+        self.media_player.durationChanged.connect(self.duration_changed)
+        self.media_player.error.connect(self.handle_video_error)
+        layout = QGridLayout(self.video_preview_widget)
+        layout.addWidget(video_widget)
+        # Enable options page on startup
+        self.main_tab.setCurrentIndex(1)
+        # Enable easing status page on startup
+        self.render_queue.status_changed.connect(self.show_status)
+        self.render_queue.processing_completed.connect(self.processing_completed)
+        self.render_queue.status_message.connect(self.show_message)
+        self.render_queue.image_rendered.connect(self.load_image)
+
+        self.movie_task = None
+
+        self.preview_frame_spin.valueChanged.connect(self.show_preview_for_frame)
+
+        self.register_data_defined_button(
+            self.scale_min_dd_btn, AnimationController.PROPERTY_MIN_SCALE
+        )
+        self.register_data_defined_button(
+            self.scale_max_dd_btn, AnimationController.PROPERTY_MAX_SCALE
+        )
+
+    def close(self):  # pylint: disable=missing-function-docstring
+        self.save_state()
+        self.reject()
+
+    def closeEvent(
+        self, event
+    ):  # pylint: disable=missing-function-docstring,unused-argument
+        self.save_state()
+        self.reject()
+
+    def _layer_changed(self, layer):
+        """
+        Triggered when the layer is changed
+        """
+        self.expression_context_generator.set_layer(layer)
+
+        buttons = self.findChildren(QgsPropertyOverrideButton)
+        for button in buttons:
+            button.setVectorLayer(layer)
+
+    def register_data_defined_button(self, button, property_key: int):
+        """
+        Registers a new data defined button, linked to the given property key (see values in AnimationController)
+        """
+        button.init(
+            property_key,
+            self.data_defined_properties,
+            AnimationController.DYNAMIC_PROPERTIES,
+            None,
+            False,
+        )
+        button.changed.connect(self._update_property)
+        button.registerExpressionContextGenerator(self.expression_context_generator)
+        button.setVectorLayer(self.layer_combo.currentLayer())
+
+    def _update_property(self):
+        """
+        Triggered when a property override button value is changed
+        """
+        button = self.sender()
+        self.data_defined_properties.setProperty(
+            button.propertyKey(), button.toProperty()
+        )
+
+    def update_data_defined_button(self, button):
+        """
+        Updates the current state of a property override button to reflect the current
+        property value
+        """
+        if button.propertyKey() < 0:
+            return
+
+        button.blockSignals(True)
+        button.setToProperty(
+            self.data_defined_properties.property(button.propertyKey())
+        )
+        button.blockSignals(False)
+
+    def show_message(self, message: str):
+        """
+        Shows a log message in the dialog
+        """
+        self.output_log_text_edit.append(message)
+
+    def show_non_fixed_extent_settings(self):
+        """
+        Switches to the non-fixed extent settings page
+        """
+        self.settings_stack.setCurrentIndex(0)
+
+    def show_fixed_extent_settings(self):
+        """
+        Switches to the fixed extent settings page
+        """
+        self.settings_stack.setCurrentIndex(1)
+
+    def show_status(self):
+        """
+        Display the size of the QgsTaskManager queue.
+
+        :returns: None
+        """
+        self.active_lcd.display(self.render_queue.active_queue_size())
+        self.total_tasks_lcd.display(self.render_queue.total_queue_size)
+        self.remaining_features_lcd.display(
+            self.render_queue.total_feature_count
+            - self.render_queue.completed_feature_count
+        )
+        self.completed_tasks_lcd.display(self.render_queue.total_completed)
+        self.completed_features_lcd.display(self.render_queue.completed_feature_count)
+
+        self.progress_bar.setValue(self.render_queue.total_completed)
+
+    def set_output_name(self):
+        """
+        Asks the user for the output video file path
+        """
+        # Popup a dialog to request the filename if scenario_file_path = None
+        dialog_title = "Save video"
+        ok_button = self.button_box.button(QDialogButtonBox.Ok)
+        ok_button.setText("Run")
+        ok_button.setEnabled(False)
+
+        output_directory = os.path.dirname(self.movie_file_edit.text())
+        if not output_directory:
+            output_directory = self.work_directory
+
+        # noinspection PyCallByClass,PyTypeChecker
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            dialog_title,
+            os.path.join(output_directory, "qgis_animation.mp4"),
+            "Video (*.mp4);;GIF (*.gif)",
+        )
+        if file_path is None or file_path == "":
+            ok_button.setEnabled(False)
+            return
+        ok_button.setEnabled(True)
+        self.movie_file_edit.setText(file_path)
+
+    def choose_music_file(self):
+        """
+        Asks the user for the music file path
+        """
+        # Popup a dialog to request the filename for music backing track
+        dialog_title = "Music for video"
+
+        # noinspection PyCallByClass,PyTypeChecker
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            dialog_title,
+            self.music_file_edit.text(),
+            "Mp3 (*.mp3);;Wav (*.wav)",
+        )
+        if file_path is None or file_path == "":
+            return
+        self.music_file_edit.setText(file_path)
+
+    def save_state(self):
+        """
+        We save some project settings to both QSettings AND the current project,
+        others just to the current project, others just to settings...
+        """
+        set_setting(
+            key="frames_per_second",
+            value=self.framerate_spin.value(),
+            store_in_project=True,
+        )
+
+        if self.radio_sphere.isChecked():
+            set_setting(key="map_mode", value="sphere", store_in_project=True)
+        elif self.radio_planar.isChecked():
+            set_setting(key="map_mode", value="planar", store_in_project=True)
+        else:
+            set_setting(key="map_mode", value="fixed_extent", store_in_project=True)
+        set_setting(
+            key="hover_duration",
+            value=self.hover_duration_spin.value(),
+            store_in_project=True,
+        )
+        set_setting(
+            key="travel_duration",
+            value=self.travel_duration_spin.value(),
+            store_in_project=True,
+        )
+        set_setting(
+            key="loop",
+            value="true" if self.check_loop_features.isChecked() else "false",
+            store_in_project=True,
+        )
+        set_setting(
+            key="frames_for_extent",
+            value=self.extent_frames_spin.value(),
+            store_in_project=True,
+        )
+        set_setting(
+            key="max_scale",
+            value=str(self.scale_range.maximumScale()),
+            store_in_project=True,
+        )
+        set_setting(
+            key="min_scale",
+            value=str(self.scale_range.minimumScale()),
+            store_in_project=True,
+        )
+        set_setting(
+            key="enable_pan_easing",
+            value=1 if self.pan_easing_widget.is_enabled() else 0,
+            store_in_project=True,
+        )
+        set_setting(
+            key="enable_zoom_easing",
+            value=1 if self.zoom_easing_widget.is_enabled() else 0,
+            store_in_project=True,
+        )
+        set_setting(
+            key="pan_easing",
+            value=self.pan_easing_widget.easing_name() or "Linear",
+            store_in_project=True,
+        )
+        set_setting(
+            key="zoom_easing",
+            value=self.zoom_easing_widget.easing_name() or "Linear",
+            store_in_project=True,
+        )
+        set_setting(
+            key="output_file",
+            value=self.movie_file_edit.text(),
+            store_in_project=True,
+        )
+        set_setting(
+            key="music_file",
+            value=self.music_file_edit.text(),
+            store_in_project=True,
+        )
+
+        # only saved to project
+        if self.layer_combo.currentLayer():
+            QgsProject.instance().writeEntry(
+                "animation", "layer_id", self.layer_combo.currentLayer().id()
+            )
+        else:
+            QgsProject.instance().removeEntry("animation", "layer_id")
+        temp_doc = QDomDocument()
+        dd_elem = temp_doc.createElement("data_defined_properties")
+        self.data_defined_properties.writeXml(
+            dd_elem, AnimationController.DYNAMIC_PROPERTIES
+        )
+        temp_doc.appendChild(dd_elem)
+        QgsProject.instance().writeEntry(
+            "animation", "data_defined_properties", temp_doc.toString()
+        )
+
+    # Prevent the slot being called twize
+    @pyqtSlot()
+    def accept(self):
+        """Process the animation sequence.
+
+        .. note:: This is called on OK click.
+        """
+        # Enable progress page on accept
+        self.main_tab.setCurrentIndex(4)
+        # Image preview page
+        self.preview_stack.setCurrentIndex(0)
+        # Enable queue status page
+        # set parameter from dialog
+
+        if not self.reuse_cache.isChecked():
+            os.system("rm %s/%s*" % (self.work_directory, self.frame_filename_prefix))
+
+        self.save_state()
+
+        self.render_queue.reset()
+        self.last_preview_image = None
+        self.output_log_text_edit.clear()
+        self.output_log_text_edit.append("Preparing animation run. Please wait.")
+        controller = self.create_controller()
+        if not controller:
+            return
+
+        controller.reuse_cache = self.reuse_cache.isChecked()
+
+        self.render_queue.set_annotations(
+            QgsProject.instance().annotationManager().annotations()
+        )
+        self.render_queue.set_decorations(self.iface.activeDecorations())
+
+        self.output_log_text_edit.append(
+            "Generating {} frames".format(controller.total_frame_count)
+        )
+        self.progress_bar.setMaximum(controller.total_frame_count)
+        self.progress_bar.setValue(0)
+
+        def log_message(message):
+            self.output_log_text_edit.append(message)
+
+        controller.normal_message.connect(log_message)
+        if int(setting(key="verbose_mode", default=0)):
+            controller.verbose_message.connect(log_message)
+
+        self.render_queue.total_feature_count = controller.total_feature_count
+
+        # this needs reworking!
+        self.render_queue.frames_per_feature = (
+            controller.travel_duration + controller.hover_duration
+        ) * controller.frame_rate
+
+        for job in controller.create_jobs():
+            self.output_log_text_edit.append(job.file_name)
+            self.render_queue.add_job(job)
+
+        self.button_box.button(QDialogButtonBox.Cancel).setEnabled(True)
+        # Now all the tasks are prepared, start the render_queue processing
+        self.render_queue.start_processing()
+
+    def cancel_processing(self):
+        """
+        Cancels current processing
+        """
+        self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
+        self.render_queue.cancel_processing()
+        # Enable progress page
+        self.main_tab.setCurrentIndex(1)
+
+    def create_controller(self) -> Optional[AnimationController]:
+        """
+        Creates a new animation controller based on the state of the dialog
+        """
+        if self.radio_sphere.isChecked():
+            map_mode = MapMode.SPHERE
+        elif self.radio_planar.isChecked():
+            map_mode = MapMode.PLANAR
+        else:
+            map_mode = MapMode.FIXED_EXTENT
+
+        if map_mode != MapMode.FIXED_EXTENT:
+            if not self.layer_combo.currentLayer():
+                self.output_log_text_edit.append(
+                    "Cannot generate sequence without choosing a layer"
+                )
+                return None
+
+            layer_type = QgsWkbTypes.displayString(
+                int(self.layer_combo.currentLayer().wkbType())
+            )
+            layer_name = self.layer_combo.currentLayer().name()
+            self.output_log_text_edit.append(
+                "Generating flight path for %s layer: %s" % (layer_type, layer_name)
+            )
+
+        if map_mode == MapMode.FIXED_EXTENT:
+            controller = AnimationController.create_fixed_extent_controller(
+                map_settings=self.iface.mapCanvas().mapSettings(),
+                feature_layer=self.layer_combo.currentLayer() or None,
+                output_extent=QgsReferencedRectangle(
+                    self.extent_group_box.outputExtent(),
+                    self.extent_group_box.outputCrs(),
+                ),
+                total_frames=self.extent_frames_spin.value(),
+                frame_rate=self.framerate_spin.value(),
+            )
+        else:
+            try:
+                controller = AnimationController.create_moving_extent_controller(
+                    map_settings=self.iface.mapCanvas().mapSettings(),
+                    mode=map_mode,
+                    feature_layer=self.layer_combo.currentLayer(),
+                    travel_duration=self.travel_duration_spin.value(),
+                    hover_duration=self.hover_duration_spin.value(),
+                    min_scale=self.scale_range.minimumScale(),
+                    max_scale=self.scale_range.maximumScale(),
+                    loop=self.check_loop_features.isChecked(),
+                    pan_easing=self.pan_easing_widget.get_easing()
+                    if self.pan_easing_widget.is_enabled()
+                    else None,
+                    zoom_easing=self.zoom_easing_widget.get_easing()
+                    if self.zoom_easing_widget.is_enabled()
+                    else None,
+                    frame_rate=self.framerate_spin.value(),
+                )
+            except InvalidAnimationParametersException as e:
+                self.output_log_text_edit.append(f"Processing halted: {e}")
+                return None
+
+        controller.data_defined_properties = QgsPropertyCollection(
+            self.data_defined_properties
+        )
+        return controller
+
+    def processing_completed(self, success: bool):
+        """Run after all processing is done to generate gif or mp4.
+
+        .. note:: This called by process_more_tasks when all tasks are complete.
+        """
+        if not success:
+            self.output_log_text_edit.append("Canceled by user")
+            self.progress_bar.setMaximum(100)
+            self.progress_bar.setValue(0)
+            self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
+            return
+
+        self.movie_task = MovieCreationTask(
+            output_file=self.movie_file_edit.text(),
+            music_file=self.music_file_edit.text(),
+            output_format=MovieFormat.GIF
+            if self.radio_gif.isChecked()
+            else MovieFormat.MP4,
+            work_directory=self.work_directory,
+            frame_filename_prefix=self.frame_filename_prefix,
+            framerate=self.framerate_spin.value(),
+        )
+
+        def log_message(message):
+            self.output_log_text_edit.append(message)
+
+        def show_movie(movie_file: str):
+            # Video preview page
+            self.main_tab.setCurrentIndex(4)
+            self.preview_stack.setCurrentIndex(1)
+            self.media_player.setMedia(QMediaContent(QUrl.fromLocalFile(movie_file)))
+            self.play_button.setEnabled(True)
+            self.play()
+
+        def cleanup_movie_task():
+            self.movie_task = None
+
+            self.progress_bar.setMaximum(100)
+            self.progress_bar.setValue(0)
+
+        self.movie_task.message.connect(log_message)
+        self.movie_task.movie_created.connect(show_movie)
+
+        # todo - show a message based on success/fail
+        self.movie_task.taskCompleted.connect(cleanup_movie_task)
+        self.movie_task.taskTerminated.connect(cleanup_movie_task)
+
+        QgsApplication.taskManager().addTask(self.movie_task)
+
+        self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
+        self.main_tab.setCurrentIndex(1)
+
+    def show_preview_for_frame(self, frame: int):
+        """
+        Shows a preview image for a specific frame
+        """
+        if self.radio_sphere.isChecked() or self.radio_planar.isChecked():
+            if not self.layer_combo.currentLayer():
+                self.output_log_text_edit.append(
+                    "Cannot generate sequence without choosing a layer"
+                )
+                return
+        if self.current_preview_frame_render_job:
+            self.current_preview_frame_render_job.cancel()
+            self.current_preview_frame_render_job = None
+
+        controller = self.create_controller()
+        job = controller.create_job_for_frame(frame)
+        if not job:
+            return
+
+        def update_preview_image(file_name):
+            if not self.current_preview_frame_render_job:
+                return
+
+            image = QImage(file_name)
+            if not image.isNull():
+                pixmap = QPixmap.fromImage(image)
+                self.user_defined_preview.setPixmap(pixmap)
+                self.current_frame_preview.setPixmap(pixmap)
+
+            self.current_preview_frame_render_job = None
+
+        job.file_name = "/tmp/tmp_image.png"
+        self.current_preview_frame_render_job = job.create_task()
+
+        self.current_preview_frame_render_job.taskCompleted.connect(
+            partial(update_preview_image, file_name=job.file_name)
+        )
+        self.current_preview_frame_render_job.taskTerminated.connect(
+            partial(update_preview_image, file_name=job.file_name)
+        )
+
+        QgsApplication.taskManager().addTask(self.current_preview_frame_render_job)
+
+    def load_image(self, name):
+        """
+        Loads a preview image
+        """
+        if self.last_preview_image is not None and self.last_preview_image > name:
+            # Images won't necessarily be rendered in order, so only update the
+            # preview image if the rendered image is from later in the animation
+            # vs the one we are currently showing. Avoids the preview jumping
+            # forward and backward and zooming/in out in unpredictable patterns
+            return
+
+        self.last_preview_image = name
+        # Load the preview with the named image file
+        if True:  # pylint: disable=using-constant-test
+            with open(name, "rb") as image_file:
+                content = image_file.read()
+                image = QImage()
+                image.loadFromData(content)
+                pixmap = QPixmap.fromImage(image)
+                self.user_defined_preview.setPixmap(pixmap)
+                self.current_frame_preview.setPixmap(pixmap)
+        else:  # this should be an except, but I'm not sure what the specific exception was supposed to be!
+            pass
+
+    # Video Playback Methods
+    def play(self):
+        """
+        Plays the video preview
+        """
+        if self.media_player.state() == QMediaPlayer.PlayingState:
+            self.media_player.pause()
+        else:
+            self.media_player.play()
+
+    def media_state_changed(self, state):  # pylint: disable=unused-argument
+        """
+        Called when the media state is changed
+        """
+        if self.media_player.state() == QMediaPlayer.PlayingState:
+            self.play_button.setIcon(self.style().standardIcon(QStyle.SP_MediaPause))
+        else:
+            self.play_button.setIcon(self.style().standardIcon(QStyle.SP_MediaPlay))
+
+    def position_changed(self, position):
+        """
+        Called when the video position changes
+        """
+        self.video_slider.setValue(position)
+
+    def duration_changed(self, duration):
+        """
+        Called when the video duration changes
+        """
+        self.video_slider.setRange(0, duration)
+
+    def set_position(self, position):
+        """
+        Sets the position of the playing video
+        """
+        self.media_player.setPosition(position)
+
+    def handle_video_error(self):
+        """
+        Handles errors when playing videos
+        """
+        self.play_button.setEnabled(False)
+        self.output_log_text_edit.append(self.media_player.errorString())

--- a/animation_workbench/core/animation_workbench.py
+++ b/animation_workbench/core/animation_workbench.py
@@ -108,7 +108,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         QDialog.__init__(self, parent)
         self.setupUi(self)
         self.expression_context_generator = DialogExpressionContextGenerator()
-        self.main_tab.setCurrentIndex(1)
+        self.main_tab.setCurrentIndex(0)
         self.extent_group_box = QgsExtentWidget(None, QgsExtentWidget.ExpandedStyle)
         vbox_layout = QVBoxLayout()
         vbox_layout.addWidget(self.extent_group_box)
@@ -370,7 +370,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         layout = QGridLayout(self.video_preview_widget)
         layout.addWidget(video_widget)
         # Enable options page on startup
-        self.main_tab.setCurrentIndex(1)
+        self.main_tab.setCurrentIndex(0)
         # Enable easing status page on startup
         self.render_queue.status_changed.connect(self.show_status)
         self.render_queue.processing_completed.connect(self.processing_completed)
@@ -690,7 +690,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
         self.render_queue.cancel_processing()
         # Enable progress page
-        self.main_tab.setCurrentIndex(1)
+        self.main_tab.setCurrentIndex(0)
 
     def create_controller(self) -> Optional[AnimationController]:
         """
@@ -807,7 +807,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
         QgsApplication.taskManager().addTask(self.movie_task)
 
         self.button_box.button(QDialogButtonBox.Cancel).setEnabled(False)
-        self.main_tab.setCurrentIndex(1)
+        self.main_tab.setCurrentIndex(0)
 
     def show_preview_for_frame(self, frame: int):
         """

--- a/animation_workbench/core/utilities.py
+++ b/animation_workbench/core/utilities.py
@@ -18,6 +18,7 @@ __revision__ = "$Format:%H$"
 # (at your option) any later version.
 # ---------------------------------------------------------------------
 
+from math import floor
 import os
 import sys
 
@@ -83,3 +84,31 @@ class CoreUtils:
                     result.append(path_extensions)
 
         return result
+
+
+def calculate_cardinality(angle):
+    """Compute the cardinality of an angle.
+
+    ..versionadded: 1.0
+
+    ..notes: Adapted from original function with the same
+        name I wrote for InaSAFE.
+
+    :param angle: Bearing angle.
+    :type angle: float
+
+    :return: Cardinality text.
+    :rtype: str
+    """
+    # this method could still be improved later, since the acquisition interval
+    # is a bit strange, i.e the input angle of 22.499° will return `N` even
+    # though 22.5° is the direction for `NNE`
+
+    direction_list = ("N,NNE,NE,ENE,E,ESE,SE,SSE,S,SSW,SW,WSW,W,WNW,NW,NNW").split(",")
+
+    bearing = float(angle)
+    direction_count = len(direction_list)
+    direction_interval = 360.0 / direction_count
+    index = int(floor(bearing / direction_interval))
+    index %= direction_count
+    return direction_list[index]

--- a/animation_workbench/ui/animation_workbench_base.ui
+++ b/animation_workbench/ui/animation_workbench_base.ui
@@ -36,23 +36,6 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="intro_outro_tab">
-      <attribute name="title">
-       <string>Intro/Outro</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_13">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>This page is coming soon. It will let you create a list of media (images and videos) that should be  inserted into the front and back of the output video.</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
      <widget class="QWidget" name="animation_plan_tab" native="true">
       <attribute name="title">
        <string>Animation Plan</string>
@@ -544,6 +527,23 @@ how many frames per second to use.</string>
            </item>
           </layout>
          </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="intro_outro_tab">
+      <attribute name="title">
+       <string>Intro/Outro</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_13">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>This page is coming soon. It will let you create a list of media (images and videos) that should be  inserted into the front and back of the output video.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
         </widget>
        </item>
       </layout>

--- a/animation_workbench/ui/animation_workbench_base.ui
+++ b/animation_workbench/ui/animation_workbench_base.ui
@@ -40,6 +40,18 @@
       <attribute name="title">
        <string>Intro/Outro</string>
       </attribute>
+      <layout class="QGridLayout" name="gridLayout_13">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>This page is coming soon. It will let you create a list of media (images and videos) that should be  inserted into the front and back of the output video.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="animation_plan_tab" native="true">
       <attribute name="title">

--- a/animation_workbench/ui/animation_workbench_base.ui
+++ b/animation_workbench/ui/animation_workbench_base.ui
@@ -13,951 +13,15 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_13">
-   <item row="0" column="0">
-    <widget class="QStackedWidget" name="main_stack">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="options_page">
-      <layout class="QGridLayout" name="gridLayout_19">
-       <item row="0" column="0">
-        <widget class="QFrame" name="options_frame">
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_20">
-          <item row="0" column="0">
-           <widget class="QFrame" name="frame">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_14">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QScrollArea" name="scrollArea">
-               <property name="frameShadow">
-                <enum>QFrame::Plain</enum>
-               </property>
-               <property name="lineWidth">
-                <number>0</number>
-               </property>
-               <property name="widgetResizable">
-                <bool>true</bool>
-               </property>
-               <widget class="QWidget" name="scrollAreaWidgetContents">
-                <property name="geometry">
-                 <rect>
-                  <x>0</x>
-                  <y>0</y>
-                  <width>1039</width>
-                  <height>842</height>
-                 </rect>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_22">
-                 <item row="0" column="0">
-                  <widget class="QGroupBox" name="render_mode_group">
-                   <property name="toolTip">
-                    <string>The render mode determines the behaviour and type of the animation.
-For 'Sphere' the coordinate reference system (CRS) will
-be manipulated to create a spinning globe effect.
-For 'Plane', the CRS will not be altered, but will pan and
-zoom to each point.</string>
-                   </property>
-                   <property name="title">
-                    <string>Render Mode</string>
-                   </property>
-                   <layout class="QGridLayout" name="gridLayout">
-                    <item row="0" column="0">
-                     <widget class="QRadioButton" name="radio_sphere">
-                      <property name="text">
-                       <string>Sphere</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QRadioButton" name="radio_planar">
-                      <property name="text">
-                       <string>Planar</string>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="2">
-                     <widget class="QRadioButton" name="radio_extent">
-                      <property name="text">
-                       <string>Fixed Extent</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QGroupBox" name="animation_layer_group">
-                   <property name="title">
-                    <string>Animation Layer</string>
-                   </property>
-                   <layout class="QGridLayout" name="gridLayout_2">
-                    <item row="0" column="0" colspan="2">
-                     <widget class="QgsMapLayerComboBox" name="layer_combo">
-                      <property name="allowEmptyLayer">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QCheckBox" name="check_loop_features">
-                      <property name="toolTip">
-                       <string>If checked, an extra travel stage from the final
-feature back to the first feature
-will be added, resulting in a seamless
-looping animation.</string>
-                      </property>
-                      <property name="text">
-                       <string>Loop from final feature back to first feature</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QStackedWidget" name="settings_stack">
-                   <property name="currentIndex">
-                    <number>0</number>
-                   </property>
-                   <widget class="QWidget" name="non_fixed_extent_settings">
-                    <layout class="QGridLayout" name="gridLayout_15">
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="spacing">
-                      <number>6</number>
-                     </property>
-                     <item row="1" column="0">
-                      <widget class="QGroupBox" name="zoom_range_group">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
-                       <property name="toolTip">
-                        <string>The scale range that the animation should
-move through. The smallest scale will be
-the zenith of the animation when it zooms
-out while travelling between points, and the
-largest scale will be the scale used when
-we arrive at each point.</string>
-                       </property>
-                       <property name="title">
-                        <string>Zoom Range</string>
-                       </property>
-                       <layout class="QGridLayout" name="gridLayout_10">
-                        <item row="0" column="0">
-                         <widget class="QgsScaleRangeWidget" name="scale_range">
-                          <property name="focusPolicy">
-                           <enum>Qt::StrongFocus</enum>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item row="3" column="0">
-                      <widget class="QGroupBox" name="animation_frames_group">
-                       <property name="title">
-                        <string>Animation Frames</string>
-                       </property>
-                       <layout class="QGridLayout" name="gridLayout_8">
-                        <item row="2" column="0">
-                         <widget class="QLabel" name="hover_frames_label">
-                          <property name="text">
-                           <string>Feature hover duration</string>
-                          </property>
-                          <property name="buddy">
-                           <cstring>hover_duration_spin</cstring>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="0">
-                         <widget class="QLabel" name="feature_frames_label">
-                          <property name="text">
-                           <string>Travel duration</string>
-                          </property>
-                          <property name="buddy">
-                           <cstring>travel_duration_spin</cstring>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="1">
-                         <widget class="QSpinBox" name="framerate_spin">
-                          <property name="toolTip">
-                           <string>When writing to video or gif,
-how many frames per second to use.</string>
-                          </property>
-                          <property name="suffix">
-                           <string> fps</string>
-                          </property>
-                          <property name="value">
-                           <number>30</number>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="0">
-                         <widget class="QLabel" name="label">
-                          <property name="text">
-                           <string>Frame rate per second</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="1">
-                         <widget class="QDoubleSpinBox" name="travel_duration_spin">
-                          <property name="toolTip">
-                           <string>This is the number of seconds that the animation will take during animation from one feature to the next.</string>
-                          </property>
-                          <property name="suffix">
-                           <string> s</string>
-                          </property>
-                          <property name="maximum">
-                           <double>999999999.000000000000000</double>
-                          </property>
-                          <property name="value">
-                           <double>2.000000000000000</double>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="1">
-                         <widget class="QDoubleSpinBox" name="hover_duration_spin">
-                          <property name="toolTip">
-                           <string>This is the number of seconds that the animation will hover over each feature.</string>
-                          </property>
-                          <property name="suffix">
-                           <string> s</string>
-                          </property>
-                          <property name="maximum">
-                           <double>9999999999.000000000000000</double>
-                          </property>
-                          <property name="value">
-                           <double>2.000000000000000</double>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                     <item row="2" column="0">
-                      <widget class="QGroupBox" name="groupBox_2">
-                       <property name="title">
-                        <string>Data Defined Settings</string>
-                       </property>
-                       <layout class="QGridLayout" name="gridLayout_17" columnstretch="0,0,0,0,0,0,1">
-                        <item row="0" column="4">
-                         <widget class="QLabel" name="mCoordYLabel">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="text">
-                           <string>Maximum</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="5">
-                         <widget class="QgsPropertyOverrideButton" name="scale_max_dd_btn">
-                          <property name="text">
-                           <string>…</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="0">
-                         <widget class="QLabel" name="mCoordXLabel">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="text">
-                           <string>Scale </string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="2">
-                         <widget class="QLabel" name="mCoordXLabel_2">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="text">
-                           <string>Minimum</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="3">
-                         <widget class="QgsPropertyOverrideButton" name="scale_min_dd_btn">
-                          <property name="text">
-                           <string>…</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="1">
-                         <spacer name="horizontalSpacer_6">
-                          <property name="orientation">
-                           <enum>Qt::Horizontal</enum>
-                          </property>
-                          <property name="sizeHint" stdset="0">
-                           <size>
-                            <width>40</width>
-                            <height>20</height>
-                           </size>
-                          </property>
-                         </spacer>
-                        </item>
-                        <item row="0" column="6">
-                         <spacer name="horizontalSpacer_7">
-                          <property name="orientation">
-                           <enum>Qt::Horizontal</enum>
-                          </property>
-                          <property name="sizeHint" stdset="0">
-                           <size>
-                            <width>40</width>
-                            <height>20</height>
-                           </size>
-                          </property>
-                         </spacer>
-                        </item>
-                       </layout>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                   <widget class="QWidget" name="fixed_extent_settings">
-                    <layout class="QGridLayout" name="gridLayout_16">
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="extent_label">
-                       <property name="text">
-                        <string>Extent</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0" colspan="2">
-                      <widget class="QWidget" name="extent_widget_container" native="true"/>
-                     </item>
-                     <item row="2" column="0">
-                      <widget class="QLabel" name="extent_frames_label">
-                       <property name="text">
-                        <string>Frames</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QSpinBox" name="extent_frames_spin">
-                       <property name="maximum">
-                        <number>9000000</number>
-                       </property>
-                       <property name="singleStep">
-                        <number>30</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="1">
-                      <spacer name="verticalSpacer">
-                       <property name="orientation">
-                        <enum>Qt::Vertical</enum>
-                       </property>
-                       <property name="sizeHint" stdset="0">
-                        <size>
-                         <width>20</width>
-                         <height>117</height>
-                        </size>
-                       </property>
-                      </spacer>
-                     </item>
-                    </layout>
-                   </widget>
-                  </widget>
-                 </item>
-                 <item row="3" column="0">
-                  <widget class="QGroupBox" name="output_options_group">
-                   <property name="toolTip">
-                    <string>Select which output format you would like.
-Regardless of which you choose, a folder
-of images will be created, one image per frame.
-For the GIF export to work, you will
-need to have the ImageMagick 'convert'  application
-available on your system. For the MP4 option to work,
-you need to have the 'ffmpeg' application on
-your system.</string>
-                   </property>
-                   <property name="title">
-                    <string>Output Options</string>
-                   </property>
-                   <layout class="QGridLayout" name="gridLayout_5">
-                    <item row="0" column="0" colspan="2">
-                     <widget class="QCheckBox" name="reuse_cache">
-                      <property name="toolTip">
-                       <string>Will not erase cached images on disk
-and will resume processing from last cached image.</string>
-                      </property>
-                      <property name="text">
-                       <string>Re-use cached images where possible</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QRadioButton" name="radio_gif">
-                      <property name="text">
-                       <string>Animated GIF</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="1">
-                     <widget class="QRadioButton" name="rad_movie">
-                      <property name="text">
-                       <string>Movie (MP4)</string>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item row="4" column="0">
-                  <widget class="QGroupBox" name="groupBox">
-                   <property name="title">
-                    <string>Soundtrack (optional)</string>
-                   </property>
-                   <layout class="QGridLayout" name="gridLayout_4">
-                    <item row="0" column="2">
-                     <widget class="QToolButton" name="music_file_button">
-                      <property name="text">
-                       <string>...</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="music_file_label">
-                      <property name="text">
-                       <string>File</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QLineEdit" name="music_file_edit"/>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item row="5" column="0">
-                  <widget class="QGroupBox" name="output_destination_group">
-                   <property name="title">
-                    <string>Output Destination</string>
-                   </property>
-                   <layout class="QGridLayout" name="gridLayout_6">
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="movie_file_label">
-                      <property name="text">
-                       <string>File</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QLineEdit" name="movie_file_edit">
-                      <property name="toolTip">
-                       <string>The output folder will be populated with
-all of the frames of the animation, and
-the GIF or MP4 as selected above.</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="2">
-                     <widget class="QToolButton" name="movie_file_button">
-                      <property name="text">
-                       <string>...</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QFrame" name="easings_frame">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>550</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_18">
-             <item row="4" column="0">
-              <widget class="QLabel" name="preview_label">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Frame Preview</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="user_defined_preview">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>250</width>
-                 <height>150</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>500</width>
-                 <height>300</height>
-                </size>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">background: white;</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="scaledContents">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_easings">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Pan and Zoom Easings</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="EasingPreview" name="zoom_easing_widget" native="true">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>250</width>
-                 <height>150</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>500</width>
-                 <height>300</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="0">
-              <widget class="QSpinBox" name="preview_frame_spin">
-               <property name="maximum">
-                <number>999999999</number>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="0">
-              <widget class="QLabel" name="preview_number_label">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Frame</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="EasingPreview" name="pan_easing_widget" native="true">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>250</width>
-                 <height>150</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>500</width>
-                 <height>300</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <spacer name="verticalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="progress_page">
-      <layout class="QGridLayout" name="gridLayout_7">
-       <item row="0" column="0">
-        <widget class="QFrame" name="run_frame">
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
-         </property>
-         <property name="lineWidth">
-          <number>0</number>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_12">
-          <item row="0" column="0" rowspan="2">
-           <widget class="QStackedWidget" name="preview_stack">
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <widget class="QWidget" name="preview_page">
-             <layout class="QGridLayout" name="gridLayout_9">
-              <item row="1" column="0" colspan="2">
-               <widget class="QLabel" name="current_frame_preview">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>250</width>
-                  <height>150</height>
-                 </size>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>9999999</width>
-                  <height>999999</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="scaledContents">
-                 <bool>true</bool>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="frame_preview_label">
-                <property name="text">
-                 <string>Frame Preview</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="video_page">
-             <layout class="QGridLayout" name="gridLayout_11">
-              <item row="0" column="0">
-               <widget class="QLabel" name="video_preview_label">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Video Preview</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0" colspan="2">
-               <widget class="QWidget" name="video_preview_widget" native="true">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QToolButton" name="play_button">
-                <property name="text">
-                 <string>&gt;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSlider" name="video_slider">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QGroupBox" name="progress_group">
-            <property name="title">
-             <string>Progress</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="0">
-              <widget class="QLCDNumber" name="total_tasks_lcd">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QLCDNumber" name="completed_tasks_lcd">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="total_tasks_label">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Total Tasks</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignHCenter|Qt::AlignTop</set>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="2">
-              <widget class="QLabel" name="completed_tasks_label">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Completed Tasks</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignHCenter|Qt::AlignTop</set>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLCDNumber" name="remaining_features_lcd">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QLCDNumber" name="active_lcd">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QLCDNumber" name="completed_features_lcd">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="remaining_features_label">
-               <property name="text">
-                <string>Remaining Features</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignHCenter|Qt::AlignTop</set>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QLabel" name="active_label">
-               <property name="text">
-                <string>Active Tasks</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignHCenter|Qt::AlignTop</set>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="2">
-              <widget class="QLabel" name="completed_label">
-               <property name="text">
-                <string>Features Completed</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignHCenter|Qt::AlignTop</set>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QGroupBox" name="logs_group">
-            <property name="title">
-             <string>Logs</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_21">
-             <item row="0" column="0">
-              <widget class="QTextEdit" name="output_log_text_edit">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="html">
-                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="3" column="0">
+  <layout class="QGridLayout" name="gridLayout_7">
+   <item row="1" column="0">
     <widget class="QProgressBar" name="progress_bar">
      <property name="value">
       <number>24</number>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -965,6 +29,893 @@ p, li { white-space: pre-wrap; }
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QTabWidget" name="main_tab">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="intro_outro_tab">
+      <attribute name="title">
+       <string>Intro/Outro</string>
+      </attribute>
+     </widget>
+     <widget class="QWidget" name="animation_plan_tab" native="true">
+      <attribute name="title">
+       <string>Animation Plan</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_6">
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="render_mode_group">
+         <property name="toolTip">
+          <string>The render mode determines the behaviour and type of the animation.
+For 'Sphere' the coordinate reference system (CRS) will
+be manipulated to create a spinning globe effect.
+For 'Plane', the CRS will not be altered, but will pan and
+zoom to each point.</string>
+         </property>
+         <property name="title">
+          <string>Render Mode</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
+           <widget class="QRadioButton" name="radio_sphere">
+            <property name="text">
+             <string>Sphere</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QRadioButton" name="radio_planar">
+            <property name="text">
+             <string>Planar</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QRadioButton" name="radio_extent">
+            <property name="text">
+             <string>Fixed Extent</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="1" rowspan="3">
+        <widget class="QFrame" name="easings_frame">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>550</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_18">
+          <item row="4" column="0">
+           <widget class="QLabel" name="preview_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Frame Preview</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="user_defined_preview">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>250</width>
+              <height>150</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>500</width>
+              <height>300</height>
+             </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background: white;</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_easings">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Pan and Zoom Easings</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="EasingPreview" name="zoom_easing_widget" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>250</width>
+              <height>150</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>500</width>
+              <height>300</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QSpinBox" name="preview_frame_spin">
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="preview_number_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Frame</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="EasingPreview" name="pan_easing_widget" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>250</width>
+              <height>150</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>500</width>
+              <height>300</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="animation_layer_group">
+         <property name="title">
+          <string>Animation Layer</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0" colspan="2">
+           <widget class="QgsMapLayerComboBox" name="layer_combo">
+            <property name="allowEmptyLayer">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="check_loop_features">
+            <property name="toolTip">
+             <string>If checked, an extra travel stage from the final
+feature back to the first feature
+will be added, resulting in a seamless
+looping animation.</string>
+            </property>
+            <property name="text">
+             <string>Loop from final feature back to first feature</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QStackedWidget" name="settings_stack">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="non_fixed_extent_settings">
+          <layout class="QGridLayout" name="gridLayout_15">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item row="1" column="0">
+            <widget class="QGroupBox" name="zoom_range_group">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="toolTip">
+              <string>The scale range that the animation should
+move through. The smallest scale will be
+the zenith of the animation when it zooms
+out while travelling between points, and the
+largest scale will be the scale used when
+we arrive at each point.</string>
+             </property>
+             <property name="title">
+              <string>Zoom Range</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_10">
+              <item row="0" column="0">
+               <widget class="QgsScaleRangeWidget" name="scale_range">
+                <property name="focusPolicy">
+                 <enum>Qt::StrongFocus</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QGroupBox" name="animation_frames_group">
+             <property name="title">
+              <string>Animation Frames</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_8">
+              <item row="2" column="0">
+               <widget class="QLabel" name="hover_frames_label">
+                <property name="text">
+                 <string>Feature hover duration</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="feature_frames_label">
+                <property name="text">
+                 <string>Travel duration</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QSpinBox" name="framerate_spin">
+                <property name="toolTip">
+                 <string>When writing to video or gif,
+how many frames per second to use.</string>
+                </property>
+                <property name="suffix">
+                 <string> fps</string>
+                </property>
+                <property name="value">
+                 <number>30</number>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label">
+                <property name="text">
+                 <string>Frame rate per second</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="travel_duration_spin">
+                <property name="toolTip">
+                 <string>This is the number of seconds that the animation will take during animation from one feature to the next.</string>
+                </property>
+                <property name="suffix">
+                 <string> s</string>
+                </property>
+                <property name="maximum">
+                 <double>999999999.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>2.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="hover_duration_spin">
+                <property name="toolTip">
+                 <string>This is the number of seconds that the animation will hover over each feature.</string>
+                </property>
+                <property name="suffix">
+                 <string> s</string>
+                </property>
+                <property name="maximum">
+                 <double>9999999999.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>2.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QGroupBox" name="groupBox_2">
+             <property name="title">
+              <string>Data Defined Settings</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_17" columnstretch="0,0,0,0,0,0,1">
+              <item row="0" column="4">
+               <widget class="QLabel" name="mCoordYLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Maximum</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QgsPropertyOverrideButton" name="scale_max_dd_btn">
+                <property name="text">
+                 <string>…</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="mCoordXLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Scale </string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="mCoordXLabel_2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Minimum</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QgsPropertyOverrideButton" name="scale_min_dd_btn">
+                <property name="text">
+                 <string>…</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <spacer name="horizontalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="6">
+               <spacer name="horizontalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="fixed_extent_settings">
+          <layout class="QGridLayout" name="gridLayout_16">
+           <item row="0" column="0">
+            <widget class="QLabel" name="extent_label">
+             <property name="text">
+              <string>Extent</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QWidget" name="extent_widget_container" native="true"/>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="extent_frames_label">
+             <property name="text">
+              <string>Frames</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="extent_frames_spin">
+             <property name="maximum">
+              <number>9000000</number>
+             </property>
+             <property name="singleStep">
+              <number>30</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>117</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="soundtrack_tab" native="true">
+      <attribute name="title">
+       <string>Soundtrack</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_12">
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Soundtrack (optional)</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="music_file_edit"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="music_file_label">
+            <property name="text">
+             <string>File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QToolButton" name="music_file_button">
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <spacer name="verticalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="output_tab" native="true">
+      <attribute name="title">
+       <string>Output</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_24">
+       <item row="0" column="0" colspan="3">
+        <widget class="QGroupBox" name="output_options_group">
+         <property name="toolTip">
+          <string>Select which output format you would like.
+Regardless of which you choose, a folder
+of images will be created, one image per frame.
+For the GIF export to work, you will
+need to have the ImageMagick 'convert'  application
+available on your system. For the MP4 option to work,
+you need to have the 'ffmpeg' application on
+your system.</string>
+         </property>
+         <property name="title">
+          <string>Output Options</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="radio_gif">
+            <property name="text">
+             <string>Animated GIF</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="reuse_cache">
+            <property name="toolTip">
+             <string>Will not erase cached images on disk
+and will resume processing from last cached image.</string>
+            </property>
+            <property name="text">
+             <string>Re-use cached images where possible</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QRadioButton" name="rad_movie">
+            <property name="text">
+             <string>Movie (MP4)</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="movie_file_label">
+         <property name="text">
+          <string>File</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="movie_file_edit">
+         <property name="toolTip">
+          <string>The output folder will be populated with
+all of the frames of the animation, and
+the GIF or MP4 as selected above.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QToolButton" name="movie_file_button">
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="progress_tab" native="true">
+      <attribute name="title">
+       <string>Progress</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_25">
+       <item row="0" column="0" rowspan="2">
+        <widget class="QStackedWidget" name="preview_stack">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="preview_page">
+          <layout class="QGridLayout" name="gridLayout_9">
+           <item row="1" column="0" colspan="2">
+            <widget class="QLabel" name="current_frame_preview">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>250</width>
+               <height>150</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>9999999</width>
+               <height>999999</height>
+              </size>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="scaledContents">
+              <bool>true</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="frame_preview_label">
+             <property name="text">
+              <string>Frame Preview</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="video_page">
+          <layout class="QGridLayout" name="gridLayout_11">
+           <item row="0" column="0">
+            <widget class="QLabel" name="video_preview_label">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Video Preview</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QWidget" name="video_preview_widget" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QToolButton" name="play_button">
+             <property name="text">
+              <string>&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSlider" name="video_slider">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QGroupBox" name="progress_group">
+         <property name="title">
+          <string>Progress</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLCDNumber" name="total_tasks_lcd">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLCDNumber" name="completed_tasks_lcd">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="total_tasks_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Total Tasks</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="completed_tasks_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Completed Tasks</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLCDNumber" name="remaining_features_lcd">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLCDNumber" name="active_lcd">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLCDNumber" name="completed_features_lcd">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="remaining_features_label">
+            <property name="text">
+             <string>Remaining Features</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="active_label">
+            <property name="text">
+             <string>Active Tasks</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="completed_label">
+            <property name="text">
+             <string>Features Completed</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QGroupBox" name="logs_group">
+         <property name="title">
+          <string>Logs</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_21">
+          <item row="0" column="0">
+           <widget class="QTextEdit" name="output_log_text_edit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="html">
+             <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell','Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
@@ -1001,8 +952,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>reuse_cache</tabstop>
   <tabstop>radio_gif</tabstop>
   <tabstop>rad_movie</tabstop>
-  <tabstop>movie_file_edit</tabstop>
-  <tabstop>movie_file_button</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
@nyalldawson I'm not sure if tabs are the best approach, but this moves closer to the kind of functionality I have in mind . The idea is that you can compose your video video by collating resources for the front and end of the video, define sountracks, set up your animation plan and then render it. This also addresses the issue of being able to return to the Animation planning stage after generating an animation.

![image](https://user-images.githubusercontent.com/178003/162849341-6fe60469-c5d6-44fd-9ab3-2223c7c15899.png)

Above will be replaced with two list widgets (front of video media list and end of video medi list) and two preview widgets. Also there should be some buttons to CRUD and reorder resources (image or video files) in each list. For image files, user should be able to set a duration in seconds for it to play. For video files, it should show the duration in seconds.  User should be able to drag / drop list items to set play order.

![image](https://user-images.githubusercontent.com/178003/162849361-6f65a19c-9bef-4e71-a291-4ae6454345c9.png)

![image](https://user-images.githubusercontent.com/178003/162849393-19900f19-20c3-4aa2-8954-199f350a9900.png)

The above will also be presented as a list of sound files that the user can reorder and manage. The length of each clip should be listed in the list view. The user should also be shown the total length of the movie based on the front and end matter and the animation plan.

![image](https://user-images.githubusercontent.com/178003/162849865-03bc4561-c2b1-43fe-aab5-140db8dbd12c.png)

Above tab could potentially go away in favour of #14 

![image](https://user-images.githubusercontent.com/178003/162849974-868067f6-55cc-42ba-a9e6-1776893910b2.png)


Obviously this PR only implements the tabs as shown above, but the rationale for them should hopefully be clear from above....
