### PR TITLE
Reduced default settings to be friendlier to older computers

### DIFF
--- a/animation_workbench/animation_workbench.py
+++ b/animation_workbench/animation_workbench.py
@@ -206,7 +206,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
             int(
                 setting(
                     key="frames_per_second",
-                    default="90",
+                    default="10",
                     prefer_project_setting=True,
                 )
             )
@@ -247,7 +247,7 @@ class AnimationWorkbench(QDialog, FORM_CLASS):
             int(
                 setting(
                     key="frames_for_extent",
-                    default="90",
+                    default="10",
                     prefer_project_setting=True,
                 )
             )

--- a/animation_workbench/gui/workbench_settings.py
+++ b/animation_workbench/gui/workbench_settings.py
@@ -32,7 +32,7 @@ class WorkbenchSettings(FORM_CLASS, QgsOptionsPageWidget):
         # of CPU cores you have would be a good conservative approach
         # You could probably run 100 or more on a decently specced machine
         self.spin_thread_pool_size.setValue(
-            int(setting(key="render_thread_pool_size", default=10))
+            int(setting(key="render_thread_pool_size", default=1))
         )
         # This is intended for developers to attach to the plugin using a
         # remote debugger so that they can step through the code. Do not


### PR DESCRIPTION
Overview: Reduced default rendered FPS from 90->10 and reduced default render tasks from 10->1.

I have been playing around with this plugin on an older machine and found that the renderer had a tendency to lock up the machine, due to how slow it was operating.